### PR TITLE
Remove afx foundation classes build dependency

### DIFF
--- a/dinputto8.rc
+++ b/dinputto8.rc
@@ -8,7 +8,7 @@
 //
 // Generated from the TEXTINCLUDE 2 resource.
 //
-#include "afxres.h"
+#include <windows.h>
 
 /////////////////////////////////////////////////////////////////////////////
 #undef APSTUDIO_READONLY_SYMBOLS


### PR DESCRIPTION
This is not actually needed by the library, but is required during build, and MSVC installations do not have it installed by default.

Seems to reduce release build size by ~50kb too.