### PR TITLE
Various conformance improvements

### DIFF
--- a/IDirectInputDeviceX.cpp
+++ b/IDirectInputDeviceX.cpp
@@ -208,20 +208,15 @@ HRESULT m_IDirectInputDeviceX::SetDataFormat(LPCDIDATAFORMAT lpdf)
 			}
 		}
 
-		EnterCriticalSection(&dics);
+		std::vector<DIOBJECTDATAFORMAT> rgodf(lpdf->dwNumObjs);
 
-		if (rgodf.size() < lpdf->dwNumObjs)
-		{
-			rgodf.resize(lpdf->dwNumObjs);
-		}
-
-		df = {
-			sizeof(DIDATAFORMAT),
+		const DIDATAFORMAT df {
+			sizeof(df),
 			lpdf->dwObjSize,
 			lpdf->dwFlags,
 			lpdf->dwDataSize,
 			lpdf->dwNumObjs,
-			&rgodf[0] };
+			rgodf.data() };
 
 		for (DWORD x = 0; x < df.dwNumObjs; x++)
 		{
@@ -233,11 +228,7 @@ HRESULT m_IDirectInputDeviceX::SetDataFormat(LPCDIDATAFORMAT lpdf)
 
 		Offset = 0;
 
-		HRESULT hr = ProxyInterface->SetDataFormat(&df);
-
-		LeaveCriticalSection(&dics);
-
-		return hr;
+		return ProxyInterface->SetDataFormat(&df);
 	}
 
 	return ProxyInterface->SetDataFormat(lpdf);

--- a/IDirectInputDeviceX.cpp
+++ b/IDirectInputDeviceX.cpp
@@ -25,6 +25,199 @@ const DIDATAFORMAT c_dfDIKeyboard = {
 	(LPDIOBJECTDATAFORMAT)dfDIKeyboard
 };
 
+// Our EnumObjectDataLUT contains only abstract types AXIS, BUTTON and POV, so consider it a match if
+// any bit of the type matches (e.g. DIDFT_AXIS is 3 while DIDFT_ABSAXIS is 1).
+template<typename T>
+static auto FindByDITypeAndInstance(T& collection, DWORD dwType)
+{
+	auto it = collection.lower_bound(dwType & 0xFFFFFF);
+	if (it != collection.end())
+	{
+		if (!(DIDFT_GETINSTANCE(it->first) == DIDFT_GETINSTANCE(dwType) &&
+			(DIDFT_GETTYPE(dwType) == 0 || (DIDFT_GETTYPE(dwType) & DIDFT_GETTYPE(it->first)) != 0)))
+		{
+			it = collection.end();
+		}
+	}
+	return it;
+}
+
+void m_IDirectInputDeviceX::InitializeEnumObjectData()
+{
+	DIDEVICEINSTANCE didi { sizeof(didi) };
+	if (SUCCEEDED(ProxyInterface->GetDeviceInfo(&didi)))
+	{
+		DevType7 = ConvertDevTypeTo7(GET_DIDEVICE_TYPE(didi.dwDevType));
+
+		// We only need to do this trickery for game controllers - keyboard/mice should be sorted fine
+		// If this is ever proven to be false, just add code here for other DIDEVTYPE_*
+		if (DevType7 == DIDEVTYPE_JOYSTICK)
+		{
+			// List based off the one in Wine, and restructured to match our use case better:
+			// https://gitlab.winehq.org/besentv/wine/-/blob/wine-1.5.29/dlls/dinput/data_formats.c#L82
+			// The important part is to keep instances of the same object type (axis, POV, button etc.) in order.
+			auto AddObject = [this](DWORD key, DWORD dwOfs)
+				{
+					EnumObjectDataLUT.try_emplace(key, ObjectOrderValue{ dwOfs, dwOfs });
+				};
+
+			// Axes
+			{
+				DWORD dwAxisInstanceNo = 0;
+				AddObject(DIDFT_AXIS | DIDFT_MAKEINSTANCE(dwAxisInstanceNo), DIJOFS_X); dwAxisInstanceNo++;
+				AddObject(DIDFT_AXIS | DIDFT_MAKEINSTANCE(dwAxisInstanceNo), DIJOFS_Y); dwAxisInstanceNo++;
+				AddObject(DIDFT_AXIS | DIDFT_MAKEINSTANCE(dwAxisInstanceNo), DIJOFS_Z); dwAxisInstanceNo++;
+				AddObject(DIDFT_AXIS | DIDFT_MAKEINSTANCE(dwAxisInstanceNo), DIJOFS_RX); dwAxisInstanceNo++;
+				AddObject(DIDFT_AXIS | DIDFT_MAKEINSTANCE(dwAxisInstanceNo), DIJOFS_RY); dwAxisInstanceNo++;
+				AddObject(DIDFT_AXIS | DIDFT_MAKEINSTANCE(dwAxisInstanceNo), DIJOFS_RZ); dwAxisInstanceNo++;
+				AddObject(DIDFT_AXIS | DIDFT_MAKEINSTANCE(dwAxisInstanceNo), DIJOFS_SLIDER(0)); dwAxisInstanceNo++;
+				AddObject(DIDFT_AXIS | DIDFT_MAKEINSTANCE(dwAxisInstanceNo), DIJOFS_SLIDER(1)); dwAxisInstanceNo++;
+
+				AddObject(DIDFT_AXIS | DIDFT_MAKEINSTANCE(dwAxisInstanceNo), FIELD_OFFSET(DIJOYSTATE2,lVX)); dwAxisInstanceNo++;
+				AddObject(DIDFT_AXIS | DIDFT_MAKEINSTANCE(dwAxisInstanceNo), FIELD_OFFSET(DIJOYSTATE2,lVY)); dwAxisInstanceNo++;
+				AddObject(DIDFT_AXIS | DIDFT_MAKEINSTANCE(dwAxisInstanceNo), FIELD_OFFSET(DIJOYSTATE2,lVZ)); dwAxisInstanceNo++;
+				AddObject(DIDFT_AXIS | DIDFT_MAKEINSTANCE(dwAxisInstanceNo), FIELD_OFFSET(DIJOYSTATE2,lVRx)); dwAxisInstanceNo++;
+				AddObject(DIDFT_AXIS | DIDFT_MAKEINSTANCE(dwAxisInstanceNo), FIELD_OFFSET(DIJOYSTATE2,lVRy)); dwAxisInstanceNo++;
+				AddObject(DIDFT_AXIS | DIDFT_MAKEINSTANCE(dwAxisInstanceNo), FIELD_OFFSET(DIJOYSTATE2,lVRz)); dwAxisInstanceNo++;
+				AddObject(DIDFT_AXIS | DIDFT_MAKEINSTANCE(dwAxisInstanceNo), FIELD_OFFSET(DIJOYSTATE2,rglVSlider[0])); dwAxisInstanceNo++;
+				AddObject(DIDFT_AXIS | DIDFT_MAKEINSTANCE(dwAxisInstanceNo), FIELD_OFFSET(DIJOYSTATE2,rglVSlider[1])); dwAxisInstanceNo++;
+				AddObject(DIDFT_AXIS | DIDFT_MAKEINSTANCE(dwAxisInstanceNo), FIELD_OFFSET(DIJOYSTATE2,lAX)); dwAxisInstanceNo++;
+				AddObject(DIDFT_AXIS | DIDFT_MAKEINSTANCE(dwAxisInstanceNo), FIELD_OFFSET(DIJOYSTATE2,lAY)); dwAxisInstanceNo++;
+				AddObject(DIDFT_AXIS | DIDFT_MAKEINSTANCE(dwAxisInstanceNo), FIELD_OFFSET(DIJOYSTATE2,lAZ)); dwAxisInstanceNo++;
+				AddObject(DIDFT_AXIS | DIDFT_MAKEINSTANCE(dwAxisInstanceNo), FIELD_OFFSET(DIJOYSTATE2,lARx)); dwAxisInstanceNo++;
+				AddObject(DIDFT_AXIS | DIDFT_MAKEINSTANCE(dwAxisInstanceNo), FIELD_OFFSET(DIJOYSTATE2,lARy)); dwAxisInstanceNo++;
+				AddObject(DIDFT_AXIS | DIDFT_MAKEINSTANCE(dwAxisInstanceNo), FIELD_OFFSET(DIJOYSTATE2,lARz)); dwAxisInstanceNo++;
+				AddObject(DIDFT_AXIS | DIDFT_MAKEINSTANCE(dwAxisInstanceNo), FIELD_OFFSET(DIJOYSTATE2,rglASlider[0])); dwAxisInstanceNo++;
+				AddObject(DIDFT_AXIS | DIDFT_MAKEINSTANCE(dwAxisInstanceNo), FIELD_OFFSET(DIJOYSTATE2,rglASlider[1])); dwAxisInstanceNo++;
+				AddObject(DIDFT_AXIS | DIDFT_MAKEINSTANCE(dwAxisInstanceNo), FIELD_OFFSET(DIJOYSTATE2,lFX)); dwAxisInstanceNo++;
+				AddObject(DIDFT_AXIS | DIDFT_MAKEINSTANCE(dwAxisInstanceNo), FIELD_OFFSET(DIJOYSTATE2,lFY)); dwAxisInstanceNo++;
+				AddObject(DIDFT_AXIS | DIDFT_MAKEINSTANCE(dwAxisInstanceNo), FIELD_OFFSET(DIJOYSTATE2,lFZ)); dwAxisInstanceNo++;
+				AddObject(DIDFT_AXIS | DIDFT_MAKEINSTANCE(dwAxisInstanceNo), FIELD_OFFSET(DIJOYSTATE2,lFRx)); dwAxisInstanceNo++;
+				AddObject(DIDFT_AXIS | DIDFT_MAKEINSTANCE(dwAxisInstanceNo), FIELD_OFFSET(DIJOYSTATE2,lFRy)); dwAxisInstanceNo++;
+				AddObject(DIDFT_AXIS | DIDFT_MAKEINSTANCE(dwAxisInstanceNo), FIELD_OFFSET(DIJOYSTATE2,lFRz)); dwAxisInstanceNo++;
+				AddObject(DIDFT_AXIS | DIDFT_MAKEINSTANCE(dwAxisInstanceNo), FIELD_OFFSET(DIJOYSTATE2,rglFSlider[0])); dwAxisInstanceNo++;
+				AddObject(DIDFT_AXIS | DIDFT_MAKEINSTANCE(dwAxisInstanceNo), FIELD_OFFSET(DIJOYSTATE2,rglFSlider[1])); dwAxisInstanceNo++;
+			}
+
+			// POV
+			for (DWORD dwPovNo = 0; dwPovNo < 4; ++dwPovNo)
+			{
+				AddObject(DIDFT_POV | DIDFT_MAKEINSTANCE(dwPovNo), DIJOFS_POV(dwPovNo));
+			}
+			
+			// Buttons
+			for (DWORD dwButtonNo = 0; dwButtonNo < 128; ++dwButtonNo)
+			{
+				AddObject(DIDFT_BUTTON | DIDFT_MAKEINSTANCE(dwButtonNo), DIJOFS_BUTTON(dwButtonNo));
+			}
+		}
+	}
+}
+
+void m_IDirectInputDeviceX::SetEnumObjectDataFromFormat(LPCDIDATAFORMAT lpdf)
+{
+	OffsetForMissingObjects = static_cast<DWORD>(-1);
+
+	// First set all offsets to -1, then update them for any objects that are defined
+	for (auto& element : EnumObjectDataLUT)
+	{
+		element.second.dwOfs = static_cast<DWORD>(-1);
+	}
+
+	// lpdf is most likely going to contain mostly DIDFT_ANYINSTANCE as instance numbers,
+	// so we need a map to track those by type.
+	// Mixing specific instances and DIDFT_ANYINSTANCE for the same type is not permitted,
+	// so we don't need to worry about aliasing.
+	std::map<DWORD, DWORD> InstanceNumbersByType {
+		{ DIDFT_AXIS, 0, }, { DIDFT_BUTTON, 0 }, { DIDFT_POV, 0 },
+	};
+
+	// To support proper relocation of axes with specific GUIDs, we need to "remember" their respective instance numbers.
+	// Annoying, but at least it can be contained into just this function.
+	std::list<std::pair<const GUID*, DWORD>> InstanceNumbersByGUID;
+	if (DevType7 == DIDEVTYPE_MOUSE)
+	{
+		DWORD instanceNo = 0;
+		InstanceNumbersByGUID.emplace_back(&GUID_XAxis, instanceNo++);
+		InstanceNumbersByGUID.emplace_back(&GUID_YAxis, instanceNo++);
+		InstanceNumbersByGUID.emplace_back(&GUID_ZAxis, instanceNo++);
+	}
+	else if (DevType7 == DIDEVTYPE_JOYSTICK)
+	{
+		DWORD instanceNo = 0;
+		InstanceNumbersByGUID.emplace_back(&GUID_XAxis, instanceNo++);
+		InstanceNumbersByGUID.emplace_back(&GUID_YAxis, instanceNo++);
+		InstanceNumbersByGUID.emplace_back(&GUID_ZAxis, instanceNo++);
+		InstanceNumbersByGUID.emplace_back(&GUID_RxAxis, instanceNo++);
+		InstanceNumbersByGUID.emplace_back(&GUID_RyAxis, instanceNo++);
+		InstanceNumbersByGUID.emplace_back(&GUID_RzAxis, instanceNo++);
+		InstanceNumbersByGUID.emplace_back(&GUID_Slider, instanceNo++);
+		InstanceNumbersByGUID.emplace_back(&GUID_Slider, instanceNo++);
+		InstanceNumbersByGUID.emplace_back(&GUID_XAxis, instanceNo++);
+		InstanceNumbersByGUID.emplace_back(&GUID_YAxis, instanceNo++);
+		InstanceNumbersByGUID.emplace_back(&GUID_ZAxis, instanceNo++);
+		InstanceNumbersByGUID.emplace_back(&GUID_RxAxis, instanceNo++);
+		InstanceNumbersByGUID.emplace_back(&GUID_RyAxis, instanceNo++);
+		InstanceNumbersByGUID.emplace_back(&GUID_RzAxis, instanceNo++);
+		InstanceNumbersByGUID.emplace_back(&GUID_Slider, instanceNo++);
+		InstanceNumbersByGUID.emplace_back(&GUID_Slider, instanceNo++);
+		InstanceNumbersByGUID.emplace_back(&GUID_XAxis, instanceNo++);
+		InstanceNumbersByGUID.emplace_back(&GUID_YAxis, instanceNo++);
+		InstanceNumbersByGUID.emplace_back(&GUID_ZAxis, instanceNo++);
+		InstanceNumbersByGUID.emplace_back(&GUID_RxAxis, instanceNo++);
+		InstanceNumbersByGUID.emplace_back(&GUID_RyAxis, instanceNo++);
+		InstanceNumbersByGUID.emplace_back(&GUID_RzAxis, instanceNo++);
+		InstanceNumbersByGUID.emplace_back(&GUID_Slider, instanceNo++);
+		InstanceNumbersByGUID.emplace_back(&GUID_Slider, instanceNo++);
+		InstanceNumbersByGUID.emplace_back(&GUID_XAxis, instanceNo++);
+		InstanceNumbersByGUID.emplace_back(&GUID_YAxis, instanceNo++);
+		InstanceNumbersByGUID.emplace_back(&GUID_ZAxis, instanceNo++);
+		InstanceNumbersByGUID.emplace_back(&GUID_RxAxis, instanceNo++);
+		InstanceNumbersByGUID.emplace_back(&GUID_RyAxis, instanceNo++);
+		InstanceNumbersByGUID.emplace_back(&GUID_RzAxis, instanceNo++);
+		InstanceNumbersByGUID.emplace_back(&GUID_Slider, instanceNo++);
+		InstanceNumbersByGUID.emplace_back(&GUID_Slider, instanceNo++);
+	}
+
+	const auto begin = lpdf->rgodf;
+	const auto end = begin + lpdf->dwNumObjs;
+	for (auto it = begin; it != end; ++it)
+	{
+		auto instanceNumIt = FindByDITypeAndInstance(InstanceNumbersByType, DIDFT_GETTYPE(it->dwType));
+		if (instanceNumIt != InstanceNumbersByType.end())
+		{
+			DWORD instanceNum = DIDFT_GETINSTANCE(it->dwType);
+			if (instanceNum == 0xFFFF) // Is ANYINSTANCE in use?
+			{
+				// Does this GUID have a predefined instance?
+				auto instanceGuidIt = std::find_if(InstanceNumbersByGUID.begin(), InstanceNumbersByGUID.end(),
+					[pguid = it->pguid] (const auto& e)
+					{
+						const GUID& a = pguid ? *pguid : GUID{};
+						const GUID& b = e.first ? *e.first : GUID{};
+						return memcmp(&a, &b, sizeof(GUID)) == 0;
+					});
+				if (instanceGuidIt != InstanceNumbersByGUID.end())
+				{
+					instanceNum = instanceGuidIt->second;
+					// Once a GUID has been used, "pop" it so the next object with the same GUID is used next time
+					InstanceNumbersByGUID.erase(instanceGuidIt);
+				}
+				else
+				{
+					instanceNum = instanceNumIt->second++;
+				}
+			}
+
+			auto enumObjectIt = FindByDITypeAndInstance(EnumObjectDataLUT, DIDFT_MAKEINSTANCE(instanceNum) | DIDFT_GETTYPE(it->dwType));
+			if (enumObjectIt != EnumObjectDataLUT.end())
+			{
+				enumObjectIt->second.dwOfs = it->dwOfs;
+			}
+		}	
+	}
+}
+
 HRESULT m_IDirectInputDeviceX::QueryInterface(REFIID riid, LPVOID FAR * ppvObj, DWORD DirectXVersion)
 {
 	Logging::LogDebug() << __FUNCTION__ << " (" << this << ")";
@@ -77,14 +270,118 @@ HRESULT m_IDirectInputDeviceX::GetCapabilities(LPDIDEVCAPS lpDIDevCaps)
 	return ProxyInterface->GetCapabilities(lpDIDevCaps);
 }
 
-template HRESULT m_IDirectInputDeviceX::EnumObjectsX<IDirectInputDevice8A, LPDIENUMDEVICEOBJECTSCALLBACKA>(LPDIENUMDEVICEOBJECTSCALLBACKA, LPVOID, DWORD);
-template HRESULT m_IDirectInputDeviceX::EnumObjectsX<IDirectInputDevice8W, LPDIENUMDEVICEOBJECTSCALLBACKW>(LPDIENUMDEVICEOBJECTSCALLBACKW, LPVOID, DWORD);
-template <class T, class V>
+template HRESULT m_IDirectInputDeviceX::EnumObjectsX<IDirectInputDevice8A, LPDIENUMDEVICEOBJECTSCALLBACKA, DIDEVICEOBJECTINSTANCEA>(LPDIENUMDEVICEOBJECTSCALLBACKA, LPVOID, DWORD);
+template HRESULT m_IDirectInputDeviceX::EnumObjectsX<IDirectInputDevice8W, LPDIENUMDEVICEOBJECTSCALLBACKW, DIDEVICEOBJECTINSTANCEW>(LPDIENUMDEVICEOBJECTSCALLBACKW, LPVOID, DWORD);
+template <class T, class V, class D>
 HRESULT m_IDirectInputDeviceX::EnumObjectsX(V lpCallback, LPVOID pvRef, DWORD dwFlags)
 {
 	Logging::LogDebug() << __FUNCTION__ << " (" << this << ")";
 
-	return GetProxyInterface<T>()->EnumObjects(lpCallback, pvRef, dwFlags);
+	if (!lpCallback)
+	{
+		return DIERR_INVALIDPARAM;
+	}
+
+	// EnumObjects of old DirectInput differs from DirectInput8 in three ways:
+	// 1. When the data format is set, objects not specified in that format get an offset of -1 (all DInput versions).
+	// 2. Objects are enumerated in order and with offsets that match a predefined data format, while DInput8 enumerates them in "raw data" order
+	//    (all DInput versions except for 0x700 and 0x5B2).
+	// 3. Collections are not enumerated, except for versions 0x5B2 and 0x700
+	// Second element of the pair is the sorting order (used only if needed).
+	using DeviceObjectList = std::list<std::pair<D, DWORD>>;
+
+	// Callback structure
+	struct ObjectEnumerator
+	{
+		DeviceObjectList objects;
+		const EnumObjectDataMap* pObjectDataMap = nullptr;
+		DWORD dwDefaultOffset = 0;
+		V lpCallback = nullptr;
+		LPVOID pvRef = nullptr;
+		bool bOldDInputEnumerationBehaviour = false;
+
+		static BOOL CALLBACK StoreObjectsCallback(const D* lpddoi, LPVOID pvRef)
+		{
+			ObjectEnumerator* self = static_cast<ObjectEnumerator*>(pvRef);
+
+			// Old DInput does not enumerate collections without data
+			if (self->bOldDInputEnumerationBehaviour && DIDFT_GETTYPE(lpddoi->dwType) == (DIDFT_COLLECTION|DIDFT_NODATA))
+			{
+				return DIENUM_CONTINUE;
+			}
+
+			auto& element = self->objects.emplace_back(*lpddoi, MAXDWORD);
+			if (!self->pObjectDataMap->empty())
+			{
+				// For DInput versions that reorder elements, overwrite the offset unconditionally.
+				// Otherwise, only overwrite it if it's -1 or not in the format at all.	
+				auto it = FindByDITypeAndInstance(*self->pObjectDataMap, element.first.dwType);
+				if (self->bOldDInputEnumerationBehaviour)
+				{
+					const ObjectOrderValue& objOrderValue = it != self->pObjectDataMap->end() ? it->second : ObjectOrderValue{self->dwDefaultOffset};
+					element.first.dwOfs = objOrderValue.dwOfs;
+					element.second = objOrderValue.dwSortOrder;
+				}
+				else
+				{
+					if (it != self->pObjectDataMap->end())
+					{
+						// If default offset is not 0, then it means we have set the data format
+						if (self->dwDefaultOffset != 0)
+						{
+							element.first.dwOfs = it->second.dwOfs;
+						}
+					}
+					else
+					{
+						element.first.dwOfs = self->dwDefaultOffset;
+					}
+				}
+			}
+
+			return DIENUM_CONTINUE;
+		}
+
+		static BOOL CALLBACK EnumObjectsCallback(const D* lpddoi, LPVOID pvRef)
+		{
+			const ObjectEnumerator* self = static_cast<ObjectEnumerator*>(pvRef);
+
+			D DOI;
+			CopyMemory(&DOI, lpddoi, lpddoi->dwSize);
+
+			return self->lpCallback(&DOI, self->pvRef);
+		}
+
+	} CallbackContext;
+	CallbackContext.pvRef = pvRef;
+	CallbackContext.lpCallback = lpCallback;
+	CallbackContext.bOldDInputEnumerationBehaviour = diVersion < 0x700 && diVersion != 0x5B2;
+	CallbackContext.pObjectDataMap = &EnumObjectDataLUT;
+	CallbackContext.dwDefaultOffset = OffsetForMissingObjects;
+
+	HRESULT hr = GetProxyInterface<T>()->EnumObjects(ObjectEnumerator::StoreObjectsCallback, &CallbackContext, dwFlags);
+	if (FAILED(hr))
+	{
+		return hr;
+	}
+
+	// Versions that aren't 0x5B2 and 0x700 need (stable) sorting by the sort order we prepared earlier
+	if (diVersion < 0x700 && diVersion != 0x5B2)
+	{
+		CallbackContext.objects.sort([](const auto& left, const auto& right)
+			{
+				return left.second < right.second;
+			});
+	}
+
+	for (const auto& object : CallbackContext.objects)
+	{
+		if (ObjectEnumerator::EnumObjectsCallback(&object.first, &CallbackContext) == DIENUM_STOP)
+		{
+			break;
+		}
+	}
+	return DI_OK;
 }
 
 HRESULT m_IDirectInputDeviceX::GetProperty(REFGUID rguidProp, LPDIPROPHEADER pdiph)
@@ -202,9 +499,11 @@ HRESULT m_IDirectInputDeviceX::SetDataFormat(LPCDIDATAFORMAT lpdf)
 		{
 			Offset = lpdf->rgodf[0].dwOfs - 1;
 
-			if (SUCCEEDED(ProxyInterface->SetDataFormat(&c_dfDIKeyboard)))
+			HRESULT hr = ProxyInterface->SetDataFormat(&c_dfDIKeyboard);
+			if (SUCCEEDED(hr))
 			{
-				return DI_OK;
+				SetEnumObjectDataFromFormat(&c_dfDIKeyboard);
+				return hr;
 			}
 		}
 
@@ -228,10 +527,20 @@ HRESULT m_IDirectInputDeviceX::SetDataFormat(LPCDIDATAFORMAT lpdf)
 
 		Offset = 0;
 
-		return ProxyInterface->SetDataFormat(&df);
+		HRESULT hr = ProxyInterface->SetDataFormat(&df);
+		if (SUCCEEDED(hr))
+		{
+			SetEnumObjectDataFromFormat(&df);
+		}
+		return hr;
 	}
 
-	return ProxyInterface->SetDataFormat(lpdf);
+	HRESULT hr = ProxyInterface->SetDataFormat(lpdf);
+	if (SUCCEEDED(hr))
+	{
+		SetEnumObjectDataFromFormat(lpdf);
+	}
+	return hr;
 }
 
 HRESULT m_IDirectInputDeviceX::SetEventNotification(HANDLE hEvent)
@@ -387,7 +696,7 @@ HRESULT m_IDirectInputDeviceX::EnumCreatedEffectObjects(LPDIENUMCREATEDEFFECTOBJ
 
 		static BOOL CALLBACK EnumEffectCallback(LPDIRECTINPUTEFFECT pdeff, LPVOID pvRef)
 		{
-			EffectEnumerator* self = (EffectEnumerator*)pvRef;
+			EffectEnumerator* self = static_cast<EffectEnumerator*>(pvRef);
 
 			if (pdeff)
 			{

--- a/IDirectInputDeviceX.cpp
+++ b/IDirectInputDeviceX.cpp
@@ -302,11 +302,15 @@ HRESULT m_IDirectInputDeviceX::Initialize(HINSTANCE hinst, DWORD dwVersion, REFG
 {
 	Logging::LogDebug() << __FUNCTION__ << " (" << this << ")";
 
-	HRESULT hr = ProxyInterface->Initialize(hinst, 0x0800, rguid);
-
+	HRESULT hr = hresValidInstanceAndVersion(hinst, dwVersion);
 	if (SUCCEEDED(hr))
 	{
-		diVersion = dwVersion;
+		hr = ProxyInterface->Initialize(hinst, 0x0800, rguid);
+
+		if (SUCCEEDED(hr))
+		{
+			diVersion = dwVersion;
+		}
 	}
 
 	return hr;

--- a/IDirectInputDeviceX.cpp
+++ b/IDirectInputDeviceX.cpp
@@ -302,7 +302,14 @@ HRESULT m_IDirectInputDeviceX::Initialize(HINSTANCE hinst, DWORD dwVersion, REFG
 {
 	Logging::LogDebug() << __FUNCTION__ << " (" << this << ")";
 
-	return ProxyInterface->Initialize(hinst, dwVersion, rguid);
+	HRESULT hr = ProxyInterface->Initialize(hinst, 0x0800, rguid);
+
+	if (SUCCEEDED(hr))
+	{
+		diVersion = dwVersion;
+	}
+
+	return hr;
 }
 
 HRESULT m_IDirectInputDeviceX::CreateEffect(REFGUID rguid, LPCDIEFFECT lpeff, LPDIRECTINPUTEFFECT * ppdeff, LPUNKNOWN punkOuter)
@@ -321,7 +328,10 @@ HRESULT m_IDirectInputDeviceX::CreateEffect(REFGUID rguid, LPCDIEFFECT lpeff, LP
 
 	if (SUCCEEDED(hr) && ppdeff)
 	{
-		*ppdeff = new m_IDirectInputEffect((IDirectInputEffect*)*ppdeff);
+		m_IDirectInputEffect* DIEffect = new m_IDirectInputEffect((IDirectInputEffect*)*ppdeff);
+		DIEffect->SetVersion(diVersion);
+
+		*ppdeff = DIEffect;
 	}
 	else
 	{

--- a/IDirectInputDeviceX.h
+++ b/IDirectInputDeviceX.h
@@ -7,6 +7,9 @@ private:
 	REFIID WrapperID;
 	DWORD StringType;
 
+	// Requested DirectInput version - used to alter behaviour by requested version
+	DWORD diVersion = 0;
+
 	// Version Interfaces
 	void *WrapperInterface;
 	void *WrapperInterface2;
@@ -204,4 +207,9 @@ public:
 
 	// Helper functions
 	LPVOID GetWrapperInterfaceX(DWORD DXVersion);
+
+	void SetVersion(DWORD dwVersion)
+	{
+		diVersion = dwVersion;
+	}
 };

--- a/IDirectInputDeviceX.h
+++ b/IDirectInputDeviceX.h
@@ -70,7 +70,7 @@ private:
 	template <class T>
 	inline T *GetProxyInterface() { return (T*)ProxyInterface; }
 
-	template <class T, class V, class D>
+	template <class T, class V, class D, class D_Old>
 	inline HRESULT EnumObjectsX(V lpCallback, LPVOID pvRef, DWORD dwFlags);
 
 	template <class T, class V>
@@ -145,11 +145,11 @@ public:
 	STDMETHOD(GetCapabilities)(THIS_ LPDIDEVCAPS);
 	STDMETHOD(EnumObjects)(THIS_ LPDIENUMDEVICEOBJECTSCALLBACKA lpCallback, LPVOID pvRef, DWORD dwFlags)
 	{
-		return EnumObjectsX<IDirectInputDevice8A, LPDIENUMDEVICEOBJECTSCALLBACKA, DIDEVICEOBJECTINSTANCEA>(lpCallback, pvRef, dwFlags);
+		return EnumObjectsX<IDirectInputDevice8A, LPDIENUMDEVICEOBJECTSCALLBACKA, DIDEVICEOBJECTINSTANCEA, DIDEVICEOBJECTINSTANCE_DX3A>(lpCallback, pvRef, dwFlags);
 	}
 	STDMETHOD(EnumObjects)(THIS_ LPDIENUMDEVICEOBJECTSCALLBACKW lpCallback, LPVOID pvRef, DWORD dwFlags)
 	{
-		return EnumObjectsX<IDirectInputDevice8W, LPDIENUMDEVICEOBJECTSCALLBACKW, DIDEVICEOBJECTINSTANCEW>(lpCallback, pvRef, dwFlags);
+		return EnumObjectsX<IDirectInputDevice8W, LPDIENUMDEVICEOBJECTSCALLBACKW, DIDEVICEOBJECTINSTANCEW, DIDEVICEOBJECTINSTANCE_DX3W>(lpCallback, pvRef, dwFlags);
 	}
 	STDMETHOD(GetProperty)(THIS_ REFGUID, LPDIPROPHEADER);
 	STDMETHOD(SetProperty)(THIS_ REFGUID, LPCDIPROPHEADER);

--- a/IDirectInputDeviceX.h
+++ b/IDirectInputDeviceX.h
@@ -22,14 +22,10 @@ private:
 	DWORD Offset = 0;
 
 	// Critical section for shared memory
-	CRITICAL_SECTION dics = { NULL };
+	CRITICAL_SECTION dics = {};
 
 	// For DeviceData
 	std::vector<DIDEVICEOBJECTDATA> pdod;
-
-	// For DataFormat
-	DIDATAFORMAT df = { NULL };
-	std::vector<DIOBJECTDATAFORMAT> rgodf;
 
 	// Wrapper interface functions
 	inline REFIID GetWrapperType(DWORD DirectXVersion)

--- a/IDirectInputEffect.cpp
+++ b/IDirectInputEffect.cpp
@@ -48,7 +48,14 @@ HRESULT m_IDirectInputEffect::Initialize(HINSTANCE hinst, DWORD dwVersion, REFGU
 {
 	Logging::LogDebug() << __FUNCTION__ << " (" << this << ")";
 
-	return ProxyInterface->Initialize(hinst, dwVersion, rguid);
+	HRESULT hr = ProxyInterface->Initialize(hinst, 0x0800, rguid);
+
+	if (SUCCEEDED(hr))
+	{
+		diVersion = dwVersion;
+	}
+
+	return hr;
 }
 
 HRESULT m_IDirectInputEffect::GetEffectGuid(LPGUID pguid)

--- a/IDirectInputEffect.cpp
+++ b/IDirectInputEffect.cpp
@@ -48,11 +48,15 @@ HRESULT m_IDirectInputEffect::Initialize(HINSTANCE hinst, DWORD dwVersion, REFGU
 {
 	Logging::LogDebug() << __FUNCTION__ << " (" << this << ")";
 
-	HRESULT hr = ProxyInterface->Initialize(hinst, 0x0800, rguid);
-
+	HRESULT hr = hresValidInstanceAndVersion(hinst, dwVersion);
 	if (SUCCEEDED(hr))
 	{
-		diVersion = dwVersion;
+		hr = ProxyInterface->Initialize(hinst, 0x0800, rguid);
+
+		if (SUCCEEDED(hr))
+		{
+			diVersion = dwVersion;
+		}
 	}
 
 	return hr;

--- a/IDirectInputEffect.h
+++ b/IDirectInputEffect.h
@@ -7,6 +7,9 @@ private:
 	m_IDirectInputEffect *WrapperInterface;
 	REFIID WrapperID = IID_IDirectInputEffect;
 
+	// Requested DirectInput version - used to alter behaviour by requested version
+	DWORD diVersion = 0;
+
 public:
 	m_IDirectInputEffect(IDirectInputEffect *aOriginal) : ProxyInterface(aOriginal), WrapperInterface(this)
 	{
@@ -37,4 +40,10 @@ public:
 	STDMETHOD(Download)(THIS);
 	STDMETHOD(Unload)(THIS);
 	STDMETHOD(Escape)(THIS_ LPDIEFFESCAPE);
+
+	// Helper functions
+	void SetVersion(DWORD dwVersion)
+	{
+		diVersion = dwVersion;
+	}
 };

--- a/IDirectInputX.cpp
+++ b/IDirectInputX.cpp
@@ -201,11 +201,15 @@ HRESULT m_IDirectInputX::Initialize(HINSTANCE hinst, DWORD dwVersion)
 {
 	Logging::LogDebug() << __FUNCTION__ << " (" << this << ")";
 
-	HRESULT hr = ProxyInterface->Initialize(hinst, 0x0800);
-
+	HRESULT hr = hresValidInstanceAndVersion(hinst, dwVersion);
 	if (SUCCEEDED(hr))
 	{
-		diVersion = dwVersion;
+		hr = ProxyInterface->Initialize(hinst, 0x0800);
+
+		if (SUCCEEDED(hr))
+		{
+			diVersion = dwVersion;
+		}
 	}
 
 	return hr;

--- a/IDirectInputX.cpp
+++ b/IDirectInputX.cpp
@@ -233,6 +233,7 @@ HRESULT m_IDirectInputX::CreateDeviceExX(REFGUID rguid, REFIID riid, V *ppvObj, 
 	if (SUCCEEDED(hr) && ppvObj)
 	{
 		m_IDirectInputDeviceX *DIDevice = new m_IDirectInputDeviceX((IDirectInputDevice8W*)*ppvObj, riid);
+		DIDevice->SetVersion(diVersion);
 
 		*ppvObj = (V)DIDevice->GetWrapperInterfaceX(GetGUIDVersion(riid));
 	}

--- a/IDirectInputX.h
+++ b/IDirectInputX.h
@@ -7,6 +7,9 @@ private:
 	REFIID WrapperID;
 	DWORD StringType;
 
+	// Requested DirectInput version - used to alter behaviour by requested version
+	DWORD diVersion = 0;
+
 	// Version Interfaces
 	void *WrapperInterface;
 	void *WrapperInterface2;
@@ -122,4 +125,9 @@ public:
 
 	// Helper functions
 	LPVOID GetWrapperInterfaceX(DWORD DXVersion);
+
+	void SetVersion(DWORD dwVersion)
+	{
+		diVersion = dwVersion;
+	}
 };

--- a/IDirectInputX.h
+++ b/IDirectInputX.h
@@ -39,7 +39,7 @@ private:
 	template <class T>
 	inline T *GetProxyInterface() { return (T*)ProxyInterface; }
 
-	template <class T, class V, class D>
+	template <class T, class V, class D, class D_Old>
 	inline HRESULT EnumDevicesX(DWORD, V, LPVOID, DWORD);
 
 	template <class T, class V>
@@ -93,11 +93,11 @@ public:
 	/*** IDirectInput methods ***/
 	STDMETHOD(EnumDevices)(THIS_ DWORD dwDevType, LPDIENUMDEVICESCALLBACKA lpCallback, LPVOID pvRef, DWORD dwFlags)
 	{
-		return EnumDevicesX<IDirectInput8A, LPDIENUMDEVICESCALLBACKA, DIDEVICEINSTANCEA>(dwDevType, lpCallback, pvRef, dwFlags);
+		return EnumDevicesX<IDirectInput8A, LPDIENUMDEVICESCALLBACKA, DIDEVICEINSTANCEA, DIDEVICEINSTANCE_DX3A>(dwDevType, lpCallback, pvRef, dwFlags);
 	}
 	STDMETHOD(EnumDevices)(THIS_ DWORD dwDevType, LPDIENUMDEVICESCALLBACKW lpCallback, LPVOID pvRef, DWORD dwFlags)
 	{
-		return EnumDevicesX<IDirectInput8W, LPDIENUMDEVICESCALLBACKW, DIDEVICEINSTANCEW>(dwDevType, lpCallback, pvRef, dwFlags);
+		return EnumDevicesX<IDirectInput8W, LPDIENUMDEVICESCALLBACKW, DIDEVICEINSTANCEW, DIDEVICEINSTANCE_DX3W>(dwDevType, lpCallback, pvRef, dwFlags);
 	}
 	STDMETHOD(GetDeviceStatus)(THIS_ REFGUID);
 	STDMETHOD(RunControlPanel)(THIS_ HWND, DWORD);

--- a/README.md
+++ b/README.md
@@ -22,11 +22,11 @@ Delete the `dinput.dll` files from the game's directory. You can also delete the
  * Beyond Atlantis
  * Call To Power 2
  * Castle Adventure
- * Colin McRae Rally 2
+ * Chris Sawyer's Locomotion
+ * Colin McRae Rally 2.0
  * Commandos 2
  * Commandos 3
  * Conquest: Frontier Wars
- * Chris Sawyer's Locomotion
  * Dark Reign
  * Digger XP
  * DOSBox
@@ -44,6 +44,7 @@ Delete the `dinput.dll` files from the game's directory. You can also delete the
  * Legacy of Kain: Soul Reaver
  * Lionheart: Legacy of the Crusader
  * MegaRace 3
+ * Michelin Rally Masters: Race of Champions
  * Might and Magic IX
  * Moto Racer
  * Moto Racer 2
@@ -54,12 +55,15 @@ Delete the `dinput.dll` files from the game's directory. You can also delete the
  * Raymond 2
  * Requiem: Avenging Angel
  * Settlers 3
- * Simon the Sorcerer 3D
  * Shogo
+ * Simon the Sorcerer 3D
  * Slave Zero
  * Star Wars Episode I: Racer
- * Uprising: Join or Die
+ * Swedish Touring Car Championship
+ * Swedish Touring Car Championship 2
  * Uprising 2: Lead and Destroy
+ * Uprising: Join or Die
+ * V8 Challenge
  * Vampire: The Masquerade Redemption
  * Warrior Kings
  * Warrior Kings: Battles

--- a/dinputto8.cpp
+++ b/dinputto8.cpp
@@ -20,7 +20,6 @@
 std::ofstream LOG;
 
 bool InitFlag = false;
-DWORD diVersion = 0;
 
 AddressLookupTableDinput<void> ProxyAddressLookupTable = AddressLookupTableDinput<void>();
 
@@ -99,9 +98,8 @@ HRESULT WINAPI DirectInputCreateEx(HINSTANCE hinst, DWORD dwVersion, REFIID riid
 
 	if (SUCCEEDED(hr) && lplpDD)
 	{
-		diVersion = dwVersion;
-
 		m_IDirectInputX *Interface = new m_IDirectInputX((IDirectInput8W*)*lplpDD, riid);
+		Interface->SetVersion(dwVersion);
 
 		*lplpDD = Interface->GetWrapperInterfaceX(GetGUIDVersion(riid));
 	}

--- a/dinputto8.cpp
+++ b/dinputto8.cpp
@@ -94,14 +94,18 @@ HRESULT WINAPI DirectInputCreateEx(HINSTANCE hinst, DWORD dwVersion, REFIID riid
 
 	LOG_LIMIT(3, "Redirecting 'DirectInputCreate' " << riid << " version " << Logging::hex(dwVersion) << " to --> 'DirectInput8Create'");
 
-	HRESULT hr = m_pDirectInput8Create(hinst, 0x0800, ConvertREFIID(riid), lplpDD, punkOuter);
-
-	if (SUCCEEDED(hr) && lplpDD)
+	HRESULT hr = hresValidInstanceAndVersion(hinst, dwVersion);
+	if (SUCCEEDED(hr))
 	{
-		m_IDirectInputX *Interface = new m_IDirectInputX((IDirectInput8W*)*lplpDD, riid);
-		Interface->SetVersion(dwVersion);
+		hr = m_pDirectInput8Create(hinst, 0x0800, ConvertREFIID(riid), lplpDD, punkOuter);
 
-		*lplpDD = Interface->GetWrapperInterfaceX(GetGUIDVersion(riid));
+		if (SUCCEEDED(hr) && lplpDD)
+		{
+			m_IDirectInputX *Interface = new m_IDirectInputX((IDirectInput8W*)*lplpDD, riid);
+			Interface->SetVersion(dwVersion);
+
+			*lplpDD = Interface->GetWrapperInterfaceX(GetGUIDVersion(riid));
+		}
 	}
 
 	return hr;
@@ -168,4 +172,41 @@ HRESULT WINAPI DllUnregisterServer()
 	}
 
 	return m_pDllUnregisterServer();
+}
+
+HRESULT dinputto8::hresValidInstanceAndVersion(HINSTANCE& hinst, DWORD dwVersion)
+{
+	bool bValidInstance;
+	if (hinst != nullptr)
+	{
+		wchar_t path[4];
+		bValidInstance = GetModuleFileNameW(hinst, path, std::size(path) - 1) != 0;
+	}
+	else
+	{
+		// DInput version 0x300 permits no instance...
+		bValidInstance = dwVersion == 0x300;
+	}
+
+	if (!bValidInstance)
+	{
+		return DIERR_INVALIDPARAM;
+	}
+
+	// ...but DInput8 does not, so if the instance is empty, give it one or else it'll fail.
+	if (hinst == nullptr && dwVersion == 0x300)
+	{
+		hinst = ::GetModuleHandle(nullptr);
+	}
+
+	if (dwVersion == 0x300 || dwVersion == 0x500 || dwVersion == 0x50A || dwVersion == 0x5B2 || dwVersion == 0x602 || dwVersion == 0x61A || dwVersion == 0x700)
+	{
+		return DI_OK;
+	}
+
+	if (dwVersion == 0)
+	{
+		return DIERR_NOTINITIALIZED;
+	}
+	return dwVersion < 0x700 ? DIERR_BETADIRECTINPUTVERSION : DIERR_OLDDIRECTINPUTVERSION;
 }

--- a/dinputto8.h
+++ b/dinputto8.h
@@ -45,7 +45,6 @@ namespace dinputto8
 }
 
 extern AddressLookupTableDinput<void> ProxyAddressLookupTable;
-extern DWORD diVersion;
 
 using namespace dinputto8;
 

--- a/dinputto8.h
+++ b/dinputto8.h
@@ -42,6 +42,7 @@ namespace dinputto8
 	REFIID ConvertREFIID(REFIID riid);
 	HRESULT ProxyQueryInterface(LPVOID ProxyInterface, REFIID riid, LPVOID * ppvObj, REFIID WrapperID, LPVOID WrapperInterface);
 	void WINAPI genericQueryInterface(REFIID riid, LPVOID * ppvObj);
+	HRESULT hresValidInstanceAndVersion(HINSTANCE& hinst, DWORD dwVersion);
 }
 
 extern AddressLookupTableDinput<void> ProxyAddressLookupTable;

--- a/dinputto8.vcxproj
+++ b/dinputto8.vcxproj
@@ -58,6 +58,7 @@
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <PreprocessorDefinitions>_WINDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -75,6 +76,7 @@
       <PreprocessorDefinitions>_WINDLL;DINPUTTO8NOLOG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>$(ProjectDir);Include</AdditionalIncludeDirectories>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>


### PR DESCRIPTION
This PR introduces a series of changes to improve dinputto8's behaviour with various different DirectInput versions it emulates, based on [a test app I wrote](https://gist.github.com/CookiePLMonster/250787d4bb8c0a831e3b9d7840cadad4) and docs research with @riverar. There is a lot to unpack here, with the clue of those changes already described in https://github.com/elishacloud/dinputto8/issues/19#issuecomment-1708965021, so I'll limit myself to only listing the individual changes:

1. Requested DirectInput version is now tracked by the wrapper properly, per-object. Numerous instances of the game's requested DI version "leaking" into DI8 have been fixed.
2. Reimplemented input parameter validation for `hInstance`/`dwVersion` accepting functions to exactly match the original `dinput.dll`. This fixes possible issues with:
    * Games attempting to request an invalid DI version.
    * DI3 games not passing a `hInstance` parameter - in DI3, this was allowed.
3. Hid joysticks/game controllers from DI3 games - they only enumerate from DI5 onwards.
4. Slightly refactored `m_IDirectInputX::EnumDevicesX` so it doesn't instantiate as much unused data, and to copy less - inconsistent use of enumerators confused me a lot so I refactored it, I also made the sorted device list store only references, so we copy slightly less data.
5. Refactored `m_IDirectInputDeviceX::SetDataFormat` to use local data - since the member variables it referenced were only used in this one single function, it was effectively almost a memory leak.
6. Emulated the behaviour of `IDirectInputDeviceX::EnumObjects` more correctly. This required a lot of additional bookkeeping, but I hope the end result is still understandable.
   `EnumObjects` behaves differently in DI3-6, DI7 and DI8, with DI8's behaviour matching neither - so games could be confused by the data they receive. This is the root cause of the issue mentioned in #19. I'll summarize those behaviour differences in a table - "DI5" column actually means `diVersion < 0x700 && diVersion != 0x5B2;`. `SDF` = `SetDataFormat`. DI8's enumeration behaviour is unaffected by `SetDataFormat`.

   | | DI5 (before SDF) | DI5 (after SDF) | DI7 (before SDF) | DI7 (after SDF) | DI8 |
   |--------|--------|--------|--------|--------|--------|
   | **Enumeration order** | By data layout | By data layout | Raw order | Raw order | Raw order | 
   | **dwOfs of objects** | From data layout |  From data layout | Raw offsets | From data layout | Raw offsets |
   | **dwOfs of objects not in the data format** |  | -1 | | -1 | Raw offsets |
    
    Additionally, DI5 also doesn't enumerate collections, while DI7 and DI8 do.
7. Prevented `Enum*` callbacks from presenting "oversize" structures to DI3 games. While in most cases structures have sizes declared by the app, enumeration functions are an exception and DirectInput presents games with structures of size that DInput wants. With DI3 games, this could technically lead to buffer overflow issues if they e.g. wanted to copy this data out to a buffer big enough to only store DI3 data, and if they obeyed the `dwSize` parameter from the input struct - which ends up being bigger than the game may have anticipated.
8. Changes from 6. are also mirrored in `GetObjectInfo`. I don't have a test case for this, but it's obvious from the code that my adjustments to `dwOfs` also need to happen there.

Since all games mentioned in #19 now work fine with dinputto8, I've added them to the Supported Games list.
![image](https://github.com/elishacloud/dinputto8/assets/7947461/64f8928c-93bd-492c-ad07-86cadabfb001)

Fixes #19 (and probably more games)

To @elishacloud - since I'm linking to dinputto8 from [PCGamingWiki pages of all these games](https://www.pcgamingwiki.com/wiki/Michelin_Rally_Masters:_Race_of_Champions#Game_crashes_and.2For_freezes_on_the_initial_splash_screen), I'd like to kindly ask you to publish a new binary release once this PR is reviewed, tested and merged, as right now technically these recommended fixes break controller input in DICE's games.