### PR TITLE
Convert device type in GetCapabilities

### DIFF
--- a/BuildNo.rc
+++ b/BuildNo.rc
@@ -1,1 +1,1 @@
-#define BUILD_NUMBER 56 
+#define BUILD_NUMBER 57 

--- a/IDirectInputDeviceX.cpp
+++ b/IDirectInputDeviceX.cpp
@@ -267,7 +267,17 @@ HRESULT m_IDirectInputDeviceX::GetCapabilities(LPDIDEVCAPS lpDIDevCaps)
 {
 	Logging::LogDebug() << __FUNCTION__ << " (" << this << ")";
 
-	return ProxyInterface->GetCapabilities(lpDIDevCaps);
+	HRESULT hr = ProxyInterface->GetCapabilities(lpDIDevCaps);
+
+	if (SUCCEEDED(hr) && lpDIDevCaps && lpDIDevCaps->dwSize) {
+		DWORD devType = GET_DIDEVICE_TYPE(lpDIDevCaps->dwDevType);
+		DWORD devSubType = GET_DIDEVICE_SUBTYPE(lpDIDevCaps->dwDevType);
+		DWORD devType7 = ConvertDevTypeTo7(devType);
+		DWORD devSubType7 = ConvertDevSubTypeTo7(devType, devSubType);
+		lpDIDevCaps->dwDevType = devType7 | (devSubType7 << 8);
+	}
+
+	return hr;
 }
 
 template HRESULT m_IDirectInputDeviceX::EnumObjectsX<IDirectInputDevice8A, LPDIENUMDEVICEOBJECTSCALLBACKA, DIDEVICEOBJECTINSTANCEA, DIDEVICEOBJECTINSTANCE_DX3A>(LPDIENUMDEVICEOBJECTSCALLBACKA, LPVOID, DWORD);
@@ -622,7 +632,11 @@ HRESULT m_IDirectInputDeviceX::GetDeviceInfoX(V pdidi)
 
 	if (SUCCEEDED(hr) && pdidi && pdidi->dwSize)
 	{
-		pdidi->dwDevType = ConvertDevTypeTo7(GET_DIDEVICE_TYPE(pdidi->dwDevType));
+		DWORD devType = GET_DIDEVICE_TYPE(pdidi->dwDevType);
+		DWORD devSubType = GET_DIDEVICE_SUBTYPE(pdidi->dwDevType);
+		DWORD devType7 = ConvertDevTypeTo7(devType);
+		DWORD devSubType7 = ConvertDevSubTypeTo7(devType, devSubType);
+		pdidi->dwDevType = devType7 | (devSubType7 << 8);
 	}
 
 	return hr;

--- a/IDirectInputDeviceX.cpp
+++ b/IDirectInputDeviceX.cpp
@@ -267,9 +267,15 @@ HRESULT m_IDirectInputDeviceX::GetCapabilities(LPDIDEVCAPS lpDIDevCaps)
 {
 	Logging::LogDebug() << __FUNCTION__ << " (" << this << ")";
 
+	if (!lpDIDevCaps || !lpDIDevCaps->dwSize)
+	{
+		return DIERR_INVALIDPARAM;
+	}
+
 	HRESULT hr = ProxyInterface->GetCapabilities(lpDIDevCaps);
 
-	if (SUCCEEDED(hr) && lpDIDevCaps && lpDIDevCaps->dwSize) {
+	if (SUCCEEDED(hr))
+	{
 		DWORD devType = GET_DIDEVICE_TYPE(lpDIDevCaps->dwDevType);
 		DWORD devSubType = GET_DIDEVICE_SUBTYPE(lpDIDevCaps->dwDevType);
 		DWORD devType7 = ConvertDevTypeTo7(devType);
@@ -628,9 +634,14 @@ HRESULT m_IDirectInputDeviceX::GetDeviceInfoX(V pdidi)
 {
 	Logging::LogDebug() << __FUNCTION__ << " (" << this << ")";
 
+	if (!pdidi || !pdidi->dwSize)
+	{
+		return DIERR_INVALIDPARAM;
+	}
+
 	HRESULT hr = GetProxyInterface<T>()->GetDeviceInfo(pdidi);
 
-	if (SUCCEEDED(hr) && pdidi && pdidi->dwSize)
+	if (SUCCEEDED(hr))
 	{
 		DWORD devType = GET_DIDEVICE_TYPE(pdidi->dwDevType);
 		DWORD devSubType = GET_DIDEVICE_SUBTYPE(pdidi->dwDevType);
@@ -654,6 +665,7 @@ HRESULT m_IDirectInputDeviceX::Initialize(HINSTANCE hinst, DWORD dwVersion, REFG
 	Logging::LogDebug() << __FUNCTION__ << " (" << this << ")";
 
 	HRESULT hr = hresValidInstanceAndVersion(hinst, dwVersion);
+
 	if (SUCCEEDED(hr))
 	{
 		hr = ProxyInterface->Initialize(hinst, 0x0800, rguid);


### PR DESCRIPTION
This updates `m_IDirectInputDeviceX::GetCapabilities` to convert device type from DI8 to DI7 format. I've also updated `m_IDirectInputDeviceX::GetDeviceInfoX` since it was dropping device sub-type before. This fixes a crash in Polaris SnoCross which checks device type returned by GetCapabilities.
Fixes https://github.com/elishacloud/dinputto8/issues/24.